### PR TITLE
Revert "Enable extra linters"

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,9 +52,6 @@ linters:
     - unparam
     - wastedassign
     - wrapcheck
-    - testifylint
-    - protogetter
-    - perfsprint
 
 linters-settings:
   errcheck:


### PR DESCRIPTION
This reverts commit 5d5de20f2c788c9ba82051aa62d456c155c8cd2b. This commit was merged by mistake because when the extra linters were enabled the CI started to break and the code need to be changed.